### PR TITLE
保育園マップデータの項目追加のための修正

### DIFF
--- a/cfktools/csv2geojson.py
+++ b/cfktools/csv2geojson.py
@@ -13,10 +13,10 @@ def csv2geojson(input, encoding=None):
             return csv2geojson(fin)
     reader = csv.DictReader(input)
     fields = ("HID", "Type", "Kodomo", "Name", "Label", "AgeS", "AgeE",
-              "Full", "Open", "Close", "H24", "Memo", "Extra", "Temp",
-              "Holiday", "Night", "Add1", "Add2", "TEL", "FAX", "Owner",
-              "Ownership", "Proof", "Shanai", "Y", "X", "url", "Vacancy",
-              "VacancyDate")
+              "Full", "Open", "Close", "H24", "Memo", "Extra", "Extra_type",
+              "設立年度", "プレ幼稚園", "園バス", "給食", "Temp", "Holiday",
+              "Night", "Add1", "Add2", "TEL", "FAX", "Owner", "Ownership",
+              "Proof", "Shanai", "Y", "X", "url", "Vacancy", "VacancyDate")
     data = {'type': 'FeatureCollection', "crs": {
         "type": "name",
         "properties": {


### PR DESCRIPTION
保育園マップデータの「項目追加ver（20170618完成版）」シート
以下の項目追加にあわせて修正を加えました。

<追加項目>
Extra_type, 設立年度, プレ幼稚園, 園バス, 給食

Ubuntu16.04、python3.5.2で追加項目を含むcsvファイルにて以下のコマンド正常動作確認済みです。
 python -m cfktools csv2geojson 入力csvファイルパス -o 出力先ファイルパス